### PR TITLE
[#F-15] 주문 목록 조회 및 장바구니 주문, 정보 수정 기능 추가

### DIFF
--- a/customer/src/assets/scss/main.scss
+++ b/customer/src/assets/scss/main.scss
@@ -29,3 +29,8 @@ a {
   text-decoration: none !important;
   color: black !important;
 }
+
+.link-hover:hover {
+  text-decoration: underline !important;
+}
+

--- a/customer/src/common/StyledComponents.js
+++ b/customer/src/common/StyledComponents.js
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const CustomCheckBox = styled.input`
+  &[type='checkbox'] {
+    transform : scale(1.5);
+  }
+`;

--- a/customer/src/common/Types.js
+++ b/customer/src/common/Types.js
@@ -24,3 +24,17 @@ export const itemType = [
 ];
 
 export const genderType = ["UNISEX", "MEN", "WOMEN"];
+
+export const orderStatusMap = [
+  { name: '주문 요청', value: 'REQUESTED'},
+  { name: '결제 완료', value: 'PAY_SUCCESS'},
+  { name: '주문 접수', value: 'RECEIVED'},
+  { name: '주문 취소', value: 'CANCELED'},
+  { name: '배송 진행', value: 'DELIVERING'},
+  { name: '배송 완료', value: 'DELIVERED'},
+];
+
+export const getNameByValue = (value) => {
+  const result = orderStatusMap.find((element) => element.value === value);
+  return result ? result.name : null;
+}

--- a/customer/src/components/cart/CartItem.js
+++ b/customer/src/components/cart/CartItem.js
@@ -2,6 +2,7 @@ import {Link} from "react-router-dom";
 import React, {useCallback, useEffect, useState} from "react";
 import {AiOutlineMinus, AiOutlinePlus} from "react-icons/ai";
 import {deleteCartItem, updateCartQuantity} from "../../lib/api/cart";
+import {CustomCheckBox} from "../../common/StyledComponents";
 
 const CartItem = ({item, checked, onToggleCheck}) => {
 
@@ -47,6 +48,13 @@ const CartItem = ({item, checked, onToggleCheck}) => {
     updateCartItemQuantity(qty);
   }, [quantity, price]);
 
+  const quantityKeyPress = useCallback((e) => {
+    if (e.key === 'Enter') {
+      updateCartItemQuantity(Number(quantity));
+    }
+  }, [quantity]);
+
+  // 수량 input
   const quantityHandler = useCallback((e) => {
     const value = e.target.value;
 
@@ -55,7 +63,6 @@ const CartItem = ({item, checked, onToggleCheck}) => {
     setQuantity(Number(value));
     setPrice(Number(item.price * value));
 
-    updateCartItemQuantity(Number(value));
   }, [quantity, price]);
 
   const deleteCartItemHandler = useCallback((e) => {
@@ -74,7 +81,7 @@ const CartItem = ({item, checked, onToggleCheck}) => {
       {item && (
         <tr>
           <td>
-            <input
+            <CustomCheckBox
               type="checkbox"
               checked={checked}
               onChange={() => onToggleCheck()}
@@ -96,7 +103,7 @@ const CartItem = ({item, checked, onToggleCheck}) => {
           <td>
             <div className="quantity-control">
               <button className="decrease" onClick={decrease}><AiOutlineMinus /></button>
-              <input className="quantity" onChange={quantityHandler} type="text" value={quantity} />
+              <input className="quantity" onChange={quantityHandler} onKeyPress={quantityKeyPress}  type="text" value={quantity} />
               <button className="increase" onClick={increase}><AiOutlinePlus/></button>
             </div>
           </td>

--- a/customer/src/components/cart/CartItems.js
+++ b/customer/src/components/cart/CartItems.js
@@ -1,8 +1,13 @@
 import CartItem from "./CartItem";
 import React, {useCallback, useEffect, useState} from "react";
 import {useSelector} from "react-redux";
+import {deleteCartItems} from "../../lib/api/cart";
+import {CustomCheckBox} from "../../common/StyledComponents";
+import {useNavigate} from "react-router-dom";
 
 const CartItems = () => {
+  const navigate = useNavigate();
+
   const {cartItems} = useSelector( ({cartItems}) => ({
     cartItems: cartItems.cartItems,
   }));
@@ -15,6 +20,9 @@ const CartItems = () => {
     }
   }, [cartItems]);
 
+  /**
+   * 장바구니 상품 전체 체크
+   */
   const toggleAllCheck = useCallback((e) => {
     if (e.target.checked) {
       setCheckedItems(cartItems.map(item => item.id));
@@ -23,6 +31,9 @@ const CartItems = () => {
     }
   }, [checkedItems]);
 
+  /**
+   * 장바구니 상품 개별 체크
+   */
   const toggleCheck = useCallback((itemId) => {
     if(!checkedItems) return;
 
@@ -38,16 +49,43 @@ const CartItems = () => {
     }
   }, [checkedItems]);
 
+  // 장바구니 상품 개별 삭제
+  const deleteCartItemsHandler = useCallback((e) => {
+    deleteCartItems(checkedItems)
+      .then(response => {
+        alert("삭제되었습니다.");
+        window.location.reload();
+      });
+  }, [checkedItems]);
+
+  const orderBtnHandler = useCallback((e) => {
+    navigate("/order/order-form", {
+      state: {
+        itemInfo: {
+          itemIds: checkedItems,
+        }
+      }
+    });
+  }, [checkedItems]);
+
   return (
     <>
-      <h5 className="title">장바구니 정보</h5>
+      <div className="d-flex justify-content-between align-items-center">
+        <h5 className="title">장바구니 정보 / {cartItems && (cartItems.length+"개")}</h5>
+        <button
+          className="btn-custom-border no-wrap mb-2"
+          onClick={deleteCartItemsHandler}
+        >
+          선택 삭제
+        </button>
+      </div>
       <table
         className="cart-item-table"
       >
         <thead>
         <tr>
           <th width="10%">
-            <input
+            <CustomCheckBox
               type="checkbox"
               checked={checkedItems?.length === cartItems?.length}
               onChange={toggleAllCheck}
@@ -71,6 +109,8 @@ const CartItems = () => {
         ))}
         </tbody>
       </table>
+
+      <button className="btn-order" onClick={orderBtnHandler}>주문구매</button>
     </>
   );
 }

--- a/customer/src/components/common/Header.js
+++ b/customer/src/components/common/Header.js
@@ -38,7 +38,7 @@ const Header = () => {
           </div>
         </Link>
       )}
-      <Link to="/">
+      <Link to="/mypage">
         <div className="header-wrap">
           마이페이지
         </div>
@@ -53,7 +53,7 @@ const Header = () => {
           장바구니
         </div>
       </Link>
-      <Link to="/">
+      <Link to="/orders">
         <div className="header-wrap">
             주문조회
         </div>

--- a/customer/src/components/ordered/OrderedItem.js
+++ b/customer/src/components/ordered/OrderedItem.js
@@ -1,0 +1,45 @@
+import {Link} from "react-router-dom";
+import React from "react";
+import {getNameByValue} from "../../common/Types";
+
+const OrderedItem = ({item}) => {
+
+  return (
+    <>
+      {item && (
+        <tr>
+          <td>
+              <div className="order-item-wrap">
+                <Link to={"/item/" + item.item.id}>
+                  <div className="item-image">
+                    <img src={item.item.mainImage} alt=""/>
+                  </div>
+                </Link>
+                <div className="item-article">
+                  [{item.item.brandName}] {item.item.name}_{item.item.code}
+                </div>
+              </div>
+          </td>
+          <td>
+            {item.orderDate.substr(0, 10)}
+          </td>
+          <td>
+            <Link to={`/order?orderId=${item.orderNo}`} className="link-hover">
+              {item.orderNo}
+            </Link>
+          </td>
+          <td>
+            {item.payment.toLocaleString()}원
+            <br/>
+            {item.quantity}개
+          </td>
+          <td>
+            {getNameByValue(item.orderStatus)}
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}
+
+export default OrderedItem;

--- a/customer/src/lib/api/auth.js
+++ b/customer/src/lib/api/auth.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import {removeCookie} from "../cookie";
+import client from "./client";
 
 export const signUp = async ({userId, password, phone, name }) => {
 
@@ -32,6 +33,14 @@ export const signIn = async ({id, password}) => {
     return error.response.data;
   }
 };
+
+export const loadAuthInfo = () => {
+  return client.get("/customer");
+}
+
+export const submitAuthInfo = (submitAuthData) => {
+  return client.put("/customer", submitAuthData);
+}
 
 export const signOut = () => {
   localStorage.removeItem("accessToken");

--- a/customer/src/lib/api/cart.js
+++ b/customer/src/lib/api/cart.js
@@ -8,12 +8,22 @@ export const loadCartItems = () => {
   return client.get("/customer/cart");
 }
 
+export const loadSelectCartItems = (itemIds) => {
+  return client.get(`/customer/cart/select/${itemIds}`);
+}
+
 export const updateCartQuantity = async (formData) => {
   return await client.put("/customer/cart", formData);
 }
 
 export const deleteCartItem = async (itemId) => {
   return await client.delete("/customer/cart", {
-    data: itemId
+    data: new Array(itemId)
+  });
+}
+
+export const deleteCartItems = async (itemIds) => {
+  return await client.delete("/customer/cart", {
+    data: itemIds
   });
 }

--- a/customer/src/lib/api/orderForm.js
+++ b/customer/src/lib/api/orderForm.js
@@ -1,6 +1,5 @@
 import client from "./client";
 
 export const loadItem = async ({itemId,quantity}) => {
-  return {item:await client.get(`/item/${itemId}`), quantity};
+  return {item: await client.get(`/item/${itemId}`), quantity};
 }
-

--- a/customer/src/lib/api/orderedList.js
+++ b/customer/src/lib/api/orderedList.js
@@ -1,0 +1,8 @@
+import client from "./client";
+import qs from "qs";
+
+export const loadOrderList = (page) => {
+  const queryString = qs.stringify({page});
+
+  return client.get(`/customer/order?${queryString}`);
+}

--- a/customer/src/modules/index.js
+++ b/customer/src/modules/index.js
@@ -5,6 +5,8 @@ import loading from "./loading";
 import orderForm, {orderFormSaga} from "./orderForm";
 import favoriteItems, {favoriteItemsSaga} from "./favoriteItems";
 import cartItems, {cartItemsSaga} from "./cartItems";
+import orderedList, {orderedListSaga} from "./orderedList";
+import mypage, {authInfoSaga} from "./mypage";
 
 const rootReducer = combineReducers({
   loading,
@@ -12,10 +14,19 @@ const rootReducer = combineReducers({
   orderForm,
   favoriteItems,
   cartItems,
+  orderedList,
+  mypage,
 });
 
 export function* rootSaga() {
-  yield all([categoryItemSaga(), orderFormSaga(), favoriteItemsSaga(), cartItemsSaga()]);
+  yield all([
+    categoryItemSaga(),
+    orderFormSaga(),
+    favoriteItemsSaga(),
+    cartItemsSaga(),
+    orderedListSaga(),
+    authInfoSaga(),
+  ]);
 }
 
 export default rootReducer;

--- a/customer/src/modules/mypage.js
+++ b/customer/src/modules/mypage.js
@@ -1,0 +1,63 @@
+import createRequestSaga, {createRequestActionTypes} from "../lib/createRequestSaga";
+import {createAction, handleActions} from "redux-actions";
+import {takeLatest} from "redux-saga/effects";
+import * as authAPI from "../lib/api/auth";
+
+// action
+const [LOAD_AUTH_INFO, LOAD_AUTH_INFO_SUCCESS, LOAD_AUTH_INFO_FAILURE] =
+  createRequestActionTypes("mypage/LOAD_AUTH_INFO");
+const CHANGE_FIELD = "mypage/CHANGE_FIELD";
+const UNLOAD_AUTH_INFO = "mypage/UNLOAD_AUTH_INFO";
+
+// action creators
+export const loadAuthInfo = createAction(LOAD_AUTH_INFO);
+export const unLoadAuthInfo = createAction(UNLOAD_AUTH_INFO);
+export const changeField = createAction(
+  CHANGE_FIELD,
+  ({name, value}) => ({name, value})
+);
+
+// redux-saga
+const loadAuthInfoSaga = createRequestSaga(LOAD_AUTH_INFO, authAPI.loadAuthInfo);
+
+export function* authInfoSaga() {
+  yield takeLatest(LOAD_AUTH_INFO, loadAuthInfoSaga);
+}
+
+// init
+const initialState = {
+  userId: '',
+  password: '',
+  modifyPassword: '',
+  phone: '',
+  name: '',
+  createDate: '',
+}
+
+// reducer
+const mypage = handleActions({
+    [LOAD_AUTH_INFO_SUCCESS]: (state, {payload: authInfo}) => ({
+      ...state,
+      userId: authInfo.data.userId,
+      phone: authInfo.data.phone,
+      name: authInfo.data.name,
+      createDate: authInfo.data.createDate
+    }),
+
+    [LOAD_AUTH_INFO_FAILURE]: (state, {payload: error}) => ({
+      ...state,
+      error: error.response.data,
+    }),
+
+    [CHANGE_FIELD]: (state, {payload: {name, value} }) => ({
+      ...state,
+      [name]: value
+    }),
+
+    [UNLOAD_AUTH_INFO]: () => initialState,
+  },
+
+  initialState
+);
+
+export default mypage;

--- a/customer/src/modules/orderForm.js
+++ b/customer/src/modules/orderForm.js
@@ -1,12 +1,14 @@
 import * as orderFormAPI from "../lib/api/orderForm";
-
-// action
+import * as cartAPI from "../lib/api/cart";
 import {createAction, handleActions} from "redux-actions";
 import createRequestSaga, {createRequestActionTypes} from "../lib/createRequestSaga";
 import {takeLatest} from "redux-saga/effects";
 
+// action
 const [LOAD_ITEM, LOAD_ITEM_SUCCESS, LOAD_ITEM_FAILURE] =
   createRequestActionTypes("orderForm/LOAD_ITEM");
+const [LOAD_ITEMS, LOAD_ITEMS_SUCCESS, LOAD_ITEMS_FAILURE] =
+  createRequestActionTypes("orderForm/LOAD_ITEMS");
 const CHANGE_FIELD = "orderForm/CHANGE_FIELD";
 const REGISTER_COUPON = "orderForm/REGISTER_COUPON";
 const CHANGE_PAY_METHOD = "orderForm/CHANGE_PAY_METHOD";
@@ -15,6 +17,7 @@ const UNLOAD_ORDER_FORM = "orderForm/UNLOAD_ORDER_FORM";
 
 // action creators
 export const loadItem = createAction(LOAD_ITEM, ({itemId, quantity}) => ({itemId, quantity}));
+export const loadItems = createAction(LOAD_ITEMS, (itemIds) => (itemIds));
 export const changeField = createAction(
   CHANGE_FIELD,
   ({name, value, itemId}) => ({name, value, itemId})
@@ -32,9 +35,11 @@ export const unloadOrderForm = createAction(UNLOAD_ORDER_FORM);
 
 // redux-saga
 const loadItemSaga = createRequestSaga(LOAD_ITEM, orderFormAPI.loadItem);
+const loadItemsSaga = createRequestSaga(LOAD_ITEMS, cartAPI.loadSelectCartItems);
 
 export function* orderFormSaga() {
   yield takeLatest(LOAD_ITEM, loadItemSaga);
+  yield takeLatest(LOAD_ITEMS, loadItemsSaga);
 }
 
 // init
@@ -48,8 +53,7 @@ const initialState = {
   payMethod: "",
 };
 
-const orderForm = handleActions(
-  {
+const orderForm = handleActions({
     [LOAD_ITEM_SUCCESS]: (state, { payload: {item, quantity} }) => ({
       ...state,
       items: state.items.concat({
@@ -58,6 +62,17 @@ const orderForm = handleActions(
         coupon: null,
         quantity: quantity,
       }),
+    }),
+
+    [LOAD_ITEMS_SUCCESS]: (state, {payload: item}) => ({
+      ...state,
+      items: state.items.concat(
+        item.data.data.map(i => ({
+        id: i.id,
+        data: i,
+        coupon: null,
+        quantity: i.quantity,
+      }))),
     }),
 
     [LOAD_ITEM_FAILURE]: (state, {payload: error}) => ({

--- a/customer/src/modules/orderedList.js
+++ b/customer/src/modules/orderedList.js
@@ -1,0 +1,45 @@
+import createRequestSaga, {createRequestActionTypes} from "../lib/createRequestSaga";
+import {createAction, handleActions} from "redux-actions";
+import {takeLatest} from "redux-saga/effects";
+import * as orderListAPI from "../lib/api/orderedList";
+
+// action
+const [LOAD_ORDERED_LIST, LOAD_ORDERED_LIST_SUCCESS, LOAD_ORDERED_LIST_FAILURE] =
+  createRequestActionTypes("orderedList/LOAD_ORDERED_LIST");
+const UNLOAD_ORDERED_LIST = "orderedList/UNLOAD_ORDERED_LIST";
+
+// action creators
+export const loadOrderedList = createAction(LOAD_ORDERED_LIST, (page) => (page));
+export const unLoadOrderedList = createAction(UNLOAD_ORDERED_LIST);
+
+// redux-saga
+const loadOrderedListSaga = createRequestSaga(LOAD_ORDERED_LIST, orderListAPI.loadOrderList);
+
+export function* orderedListSaga() {
+  yield takeLatest(LOAD_ORDERED_LIST, loadOrderedListSaga);
+}
+
+// init
+const initialState = {
+  ordered: [],
+  error: null,
+  page: 0,
+}
+
+const orderedList = handleActions({
+    [LOAD_ORDERED_LIST_SUCCESS]: (state, {payload: orderedList}) => (
+      console.log(orderedList),{
+      ...state,
+      ordered: orderedList.data.content,
+      page: orderedList.data.pageable.pageNumber
+    }),
+
+    [LOAD_ORDERED_LIST_FAILURE]: (state, {payload: error}) => ({
+      ...state,
+      error,
+    }),
+  },
+  initialState
+);
+
+export default orderedList;

--- a/customer/src/pages/CartPage.js
+++ b/customer/src/pages/CartPage.js
@@ -5,6 +5,9 @@ import client from "../lib/api/client";
 import {loadCartItems, unloadCartItems} from "../modules/cartItems";
 import CartItems from "../components/cart/CartItems";
 
+/** order-form.scss에 테이블 스타일 있음.
+ *
+ */
 const CartPage = () => {
   const dispatch= useDispatch();
 
@@ -36,9 +39,11 @@ const CartPage = () => {
         <Loader />
       )}
       {!loading && cartItems && cartItems.length > 0 && (
-        <div className="cart-item-container">
-          <CartItems />
-        </div>
+        <>
+          <div className="cart-item-container">
+            <CartItems />
+          </div>
+        </>
       )}
     </>
   );

--- a/customer/src/pages/MyPage.js
+++ b/customer/src/pages/MyPage.js
@@ -1,0 +1,136 @@
+import {Button, Card, Col, Form, Row} from "react-bootstrap";
+import {useCallback, useEffect} from "react";
+import {useDispatch, useSelector} from "react-redux";
+import {changeField, loadAuthInfo, unLoadAuthInfo} from "../modules/mypage";
+import client from "../lib/api/client";
+import Loader from "../components/loader/Loader";
+import {submitAuthInfo} from "../lib/api/auth";
+
+const MyPage = () => {
+  const dispatch = useDispatch();
+
+  const {mypage, loading} = useSelector(state => ({
+    ...state,
+    loading: state.loading["mypage/LOAD_AUTH_INFO"],
+  }));
+  const {userId, password, modifyPassword, phone, name, createDate} = mypage || mypage;
+
+  const inputHandler = useCallback((e) => {
+    const {name, value} = e.target;
+
+    dispatch(changeField({name,value}));
+
+  }, [dispatch]);
+
+  const submitHandler = useCallback((e) => {
+    submitAuthInfo(mypage || mypage)
+      .then(response => {
+        if(response.status === 200) {
+          alert("정보를 수정했습니다.");
+        } else {
+          alert("정보를 수정하지 못했습니다.");
+        }
+        window.location.reload();
+      })
+      .catch(error => {
+        alert("정보를 수정하지 못했습니다.");
+        window.location.reload();
+      });
+  }, [dispatch, mypage]);
+
+  useEffect(() => {
+    client.defaults.headers.common['X-AUTH-TOKEN'] = localStorage.getItem("accessToken");
+
+    dispatch(loadAuthInfo());
+
+    return () => {
+      dispatch(unLoadAuthInfo());
+    }
+  }, []);
+
+  return (
+    <div className="p-5">
+      {loading && (<Loader />)}
+      <Card>
+        <Card.Header>
+          {name || name} / 가입일 : {createDate || createDate}
+        </Card.Header>
+
+        <Card.Body>
+          <div className="info-form-container">
+            <Form>
+              <Form.Group as={Row} className="mb-3" controlId="formId">
+                <Form.Label column sm={2}>
+                  아이디
+                </Form.Label>
+                <Col sm={10}>
+                  <Form.Control
+                    name="userId"
+                    type="text"
+                    value={userId || userId}
+                    style={{background: "#eeeeee"}}
+                    readOnly/>
+                </Col>
+              </Form.Group>
+
+              <Form.Group as={Row} className="mb-3" controlId="formPassword">
+                <Form.Label column sm={2}>
+                  현재 비밀번호
+                </Form.Label>
+                <Col sm={10}>
+                  <Form.Control
+                    name="password"
+                    type="password"
+                    value={password || password}
+                    placeholder="비밀번호"
+                    onChange={inputHandler}
+                    required />
+                </Col>
+              </Form.Group>
+
+              <Form.Group as={Row} className="mb-3" controlId="formCheckPassword">
+                <Form.Label column sm={2}>
+                  변경 비밀번호
+                </Form.Label>
+                <Col sm={10}>
+                  <Form.Control
+                    name="modifyPassword"
+                    type="password"
+                    value={modifyPassword || modifyPassword}
+                    placeholder="변경 비밀번호"
+                    onChange={inputHandler}
+                    required/>
+                </Col>
+              </Form.Group>
+
+              <Form.Group as={Row} className="mb-3" controlId="formPhone">
+                <Form.Label column sm={2}>
+                  휴대폰 정보 변경
+                </Form.Label>
+                <Col sm={10}>
+                  <Form.Control
+                    name="phone"
+                    type="text"
+                    value={phone || phone}
+                    maxLength={13}
+                    placeholder="-포함"
+                    pattern="^\d{2,3}-\d{3,4}-\d{4}$"
+                    onChange={inputHandler}
+                    required/>
+                </Col>
+              </Form.Group>
+            </Form>
+          </div>
+        </Card.Body>
+
+        <Card.Footer>
+          <Col sm={{ span: 10, offset: 2 }}>
+            <Button type="button" onClick={submitHandler} style={{float: "right"}}>정보 변경</Button>
+          </Col>
+        </Card.Footer>
+      </Card>
+    </div>
+  );
+}
+
+export default MyPage;

--- a/customer/src/pages/OrderFormPage.js
+++ b/customer/src/pages/OrderFormPage.js
@@ -3,7 +3,7 @@ import React, {useCallback, useEffect} from "react";
 import Delivery from "../components/order/orderForm/Delivery";
 import OrderItems from "../components/order/orderForm/OrderItems";
 import {useDispatch, useSelector} from "react-redux";
-import {loadItem, unloadOrderForm} from "../modules/orderForm";
+import {loadItem, loadItems, unloadOrderForm} from "../modules/orderForm";
 import {useLocation} from "react-router";
 import client from "../lib/api/client";
 import DiscountInfo from "../components/order/orderForm/DiscountInfo";
@@ -13,7 +13,7 @@ const OrderFormPage = () => {
 
   const dispatch = useDispatch();
   const location = useLocation();
-  const {itemId, quantity} = location.state?.itemInfo;
+  const {itemId, quantity, itemIds} = location.state?.itemInfo;
 
   const {items, name, phone, roadAddress, postalCode, detailAddress, payMethod} = useSelector( ({orderForm}) => ({
     items: orderForm.items,
@@ -67,11 +67,16 @@ const OrderFormPage = () => {
 
   }, [items, name, phone, roadAddress, postalCode, detailAddress, payMethod]);
 
-
   useEffect(() => {
     client.defaults.headers.common['X-AUTH-TOKEN'] = localStorage.getItem("accessToken");
 
-    dispatch(loadItem({itemId, quantity}));
+    if(itemId) {
+      // 바로 구매
+      dispatch(loadItem({itemId, quantity}));
+    } else {
+      // 장바구니 구매
+      dispatch(loadItems(itemIds));
+    }
 
     return () => {
       dispatch(unloadOrderForm());

--- a/customer/src/pages/OrderedListPage.js
+++ b/customer/src/pages/OrderedListPage.js
@@ -1,0 +1,61 @@
+import React, {useEffect} from "react";
+import "../assets/scss/order-item.scss";
+import {useDispatch, useSelector} from "react-redux";
+import {loadOrderedList, unLoadOrderedList} from "../modules/orderedList";
+import client from "../lib/api/client";
+import Loader from "../components/loader/Loader";
+import OrderedItem from "../components/ordered/OrderedItem";
+
+const OrderedListPage = () => {
+  const dispatch = useDispatch();
+
+  const {ordered, error, page, loading} = useSelector(({orderedList, loading}) => ({
+    ordered: orderedList.ordered,
+    error: orderedList.error,
+    page: orderedList.page,
+    loading: loading['orderedList/LOAD_ORDERED_LIST'],
+  }));
+
+  useEffect(() => {
+    client.defaults.headers.common['X-AUTH-TOKEN'] = localStorage.getItem("accessToken");
+
+    dispatch(loadOrderedList(page));
+
+    return () => {
+      return dispatch(unLoadOrderedList());
+    }
+  },  [dispatch]);
+
+  return (
+    <div className="order-form-container">
+      <h5 className="title">주문 목록</h5>
+        <div className="order-form-wrap">
+
+        <table
+          className="order-item-table"
+        >
+          <thead>
+          <tr>
+            <th width="50%">상품 정보</th>
+            <th width="10%">주문일</th>
+            <th width="20%">주문번호</th>
+            <th width="10%">지불금액(수량)</th>
+            <th width="10%">주문상태</th>
+          </tr>
+          </thead>
+          {loading && (<><Loader /></>)}
+          {error && (error)}
+          {!loading && (
+            <tbody>
+            {ordered && ordered.map((order, index) => (
+              <OrderedItem item={order} key={index}/>
+            ))}
+            </tbody>
+          )}
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default OrderedListPage;

--- a/customer/src/pages/OrderedPage.js
+++ b/customer/src/pages/OrderedPage.js
@@ -15,6 +15,7 @@ const OrderedPage = () => {
 
     client.post("/customer/order", params.get("orderId"))
       .then(response => {
+        console.log(response);
         if(!response.data.data){
           alert("주문번호에 해당하는 상세 주문이 없습니다.");
           navigate("/");
@@ -77,16 +78,16 @@ const OrderedPage = () => {
                 {orders.orderItemDataList.map((order, index) => (
                   <tr key={index}>
                     <td>
-                      <Link to={"/item/" + order.item.id}>
-                        <div className="order-item-wrap">
-                          <div className="item-image">
-                            <img src={order.item.mainImage} alt=""/>
-                          </div>
-                          <div className="item-article">
-                            [{order.item.brandName}] {order.item.name}_{order.item.code}
-                          </div>
+                      <div className="order-item-wrap">
+                        <div className="item-image">
+                          <Link to={"/item/" + order.item.id}>
+                          <img src={order.item.mainImage} alt=""/>
+                          </Link>
                         </div>
-                      </Link>
+                        <div className="item-article">
+                          [{order.item.brandName}] {order.item.name}_{order.item.code}
+                        </div>
+                      </div>
                     </td>
                     <td>{order.quantity}개</td>
                     <td>{order.payment.toLocaleString()}원</td>

--- a/customer/src/routes/Router.js
+++ b/customer/src/routes/Router.js
@@ -9,6 +9,8 @@ import OrderFormPage from "../pages/OrderFormPage";
 import OrderedPage from "../pages/OrderedPage";
 import FavoritePage from "../pages/FavoritePage";
 import CartPage from "../pages/CartPage";
+import OrderedListPage from "../pages/OrderedListPage";
+import MyPage from "../pages/MyPage";
 
 // TODO: 지연로딩을 사용할 경우 스타일 시트를 불러오지 못해 일단 주석 처리.
 // const AuthPage = lazy(() => import("../pages/AuthPage"));
@@ -53,10 +55,12 @@ const ThemeRoutes = [
       {path: "/", element: <Navigate to="/category/TOP" />},
       {path: "/category/:type", element: <ItemListPage />},
       {path: "/item/:itemId", element: <ItemInfoPage />},
-      {path: "/order/order-form", element: <PrivateRoute element={<OrderFormPage />} />},
       {path: "/order", element: <PrivateRoute element={<OrderedPage />} />},
+      {path: "/orders", element: <PrivateRoute element={<OrderedListPage />} />},
+      {path: "/order/order-form", element: <PrivateRoute element={<OrderFormPage />} />},
       {path: "/favorites", element: <PrivateRoute element={<FavoritePage />} />},
       {path: "/cart", element: <PrivateRoute element={<CartPage />} />},
+      {path: "/mypage", element: <PrivateRoute element={<MyPage />} />},
     ]
   },
   {

--- a/provider/src/components/common/Types.js
+++ b/provider/src/components/common/Types.js
@@ -8,3 +8,17 @@ export const itemTypes = ["TOP", "OUTER", "PANTS",
   "LIFE", "CULTURE", "PET"];
 
 export const genderTypes = ["UNISEX", "MEN", "WOMEN"];
+
+export const orderStatusMap = [
+  { name: '주문 요청', value: 'REQUESTED', variant: 'outline-secondary' },
+  { name: '결제 완료', value: 'PAY_SUCCESS', variant: 'outline-success' },
+  { name: '주문 접수', value: 'RECEIVED', variant: 'outline-primary' },
+  { name: '주문 취소', value: 'CANCELED', variant: 'outline-danger' },
+  { name: '배송 진행', value: 'DELIVERING', variant: 'outline-warning' },
+  { name: '배송 완료', value: 'DELIVERED', variant: 'outline-dark' },
+];
+
+export const getNameByValue = (value) => {
+  const result = orderStatusMap.find((element) => element.value === value);
+  return result ? result.name : null;
+}

--- a/provider/src/components/orders/OrderListItem.js
+++ b/provider/src/components/orders/OrderListItem.js
@@ -1,8 +1,8 @@
-import {getNameByValue} from "../../pages/OrderPage";
 import {useCallback} from "react";
 import {useDispatch} from "react-redux";
 import {checkOrders} from "../../modules/orders";
 import {CustomCheckBox, ImgNameWrap, ItemNameDiv} from "../common/StyledComponents";
+import {getNameByValue} from "../common/Types";
 
 const OrderListItem = ({order, checked}) => {
   const dispatch = useDispatch();

--- a/provider/src/components/orders/OrderStatusButtons.js
+++ b/provider/src/components/orders/OrderStatusButtons.js
@@ -15,7 +15,9 @@ const OrderStatusButtons = () => {
   // 체크한 주문 상태 변경
   const onChangeOrders = useCallback(
     (orderStatus) => {
+      // 리로드 안하고 싶으면 리덕스 수정
       dispatch(changeOrders({checkOrderList, orderStatus}));
+      window.location.reload();
     },
     [checkOrderList, dispatch]
   );

--- a/provider/src/modules/orders.js
+++ b/provider/src/modules/orders.js
@@ -63,15 +63,15 @@ const orders = handleActions({
         : state.checkOrders.concat({cnt, orderNo})
     }),
 
-    [CHANGE_ORDERS]: (state, {payload: {checkOrderList}}) => ({
-      ...state,
-      orders: state.orders.filter(order =>
-        !checkOrderList.some(checkOrder =>
-          checkOrder.cnt === order.cnt
-          && checkOrder.orderNo === order.orderNo)
-      ),
-      checkOrders: []
-    }),
+    // [CHANGE_ORDERS]: (state, {payload: {checkOrderList}}) => ({
+    //   ...state,
+    //   orders: state.orders.filter(order =>
+    //     !checkOrderList.some(checkOrder =>
+    //       checkOrder.cnt === order.cnt
+    //       && checkOrder.orderNo === order.orderNo)
+    //   ),
+    //   checkOrders: []
+    // }),
 
     [UNLOAD_ORDERS]: () => initialState,
   },

--- a/provider/src/pages/InfoPage.js
+++ b/provider/src/pages/InfoPage.js
@@ -3,7 +3,6 @@ import {TableNav, TableTitle} from "../components/common/Table";
 import React, {useCallback, useEffect, useState} from "react";
 import "../assets/scss/info.scss";
 import "../assets/scss/debounce.scss";
-import {FaCheck, FaTimesCircle} from "react-icons/fa";
 import {getInfo, updateInfo} from "../lib/api/info";
 import {useNavigate} from "react-router-dom";
 import {BiHomeAlt} from "react-icons/bi";
@@ -66,8 +65,7 @@ const InfoPage = () => {
 
     setFormData({
       ...formData,
-
-    })
+    });
 
     const response = await updateInfo(formData);
     console.log(response);

--- a/provider/src/pages/OrderPage.js
+++ b/provider/src/pages/OrderPage.js
@@ -5,21 +5,7 @@ import {TableHeader, TableNav, TableTitle} from "../components/common/Table";
 import OrderList from "../components/orders/OrderList";
 import OrderStatusButtons from "../components/orders/OrderStatusButtons";
 import {Helmet} from "react-helmet-async";
-
-const status = [
-  { name: '주문 요청', value: 'REQUESTED', variant: 'outline-secondary' },
-  { name: '결제 완료', value: 'PAY_SUCCESS', variant: 'outline-success' },
-  { name: '주문 접수', value: 'RECEIVED', variant: 'outline-primary' },
-  { name: '주문 취소', value: 'CANCELED', variant: 'outline-danger' },
-  { name: '배송 진행', value: 'DELIVERING', variant: 'outline-warning' },
-  { name: '배송 완료', value: 'DELIVERED', variant: 'outline-dark' },
-];
-
-export const getNameByValue = (value) => {
-  const result = status.find((element) => element.value === value);
-  return result ? result.name : null;
-}
-
+import {orderStatusMap} from "../components/common/Types";
 const OrderPage = () => {
 
   const [orderStatus, setOrderStatus] = useState('PAY_SUCCESS');
@@ -34,7 +20,7 @@ const OrderPage = () => {
           <TableNav>
             <TableTitle><BiClipboard style={{marginRight: "0.6em"}} />주문 관리</TableTitle>
             <ButtonGroup style={{display:"flex", alignItems:"center"}}>
-              {status.map((radio, idx) => (
+              {orderStatusMap.map((radio, idx) => (
                 <ToggleButton
                   className="btn-status"
                   style={{width:"4.6em"}}


### PR DESCRIPTION
- 장바구니 페이지에서 수량 수정 시 엔터키를 누를 때로 변경
- 장바구니 상품 개별 삭제 추가
- 판매자 체크 주문 변경 시 확실한 데이터 가져오도록 수정. (이전: 비동기 요청으로 데이터만 필터링 했었음)